### PR TITLE
ScratchMicroengine to EicarMicroengine

### DIFF
--- a/_i18n/en/_docs/Level-0-scratch-to-eicar.md
+++ b/_i18n/en/_docs/Level-0-scratch-to-eicar.md
@@ -169,7 +169,7 @@ from microengine import Microengine
 
 EICAR = b'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
 
-class EicarMicroengine(Microengine):
+class ScratchMicroengine(Microengine):
     """Microengine which tests for the EICAR test file"""
 
     async def scan(self, guid, content):


### PR DESCRIPTION
When tried to follow the instruction a priori, the following description:

```
vim scratch.py
```

and following

```
class EicarMicroengine ....
```
does seem misleading and actually when we put scratch.py above, it fails unless it is updated into `ScratchMicroengine`.

If I am missing something here, please correct me.

